### PR TITLE
削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,55 +1,76 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_item, only: [:show, :edit, :update]
-  before_action :redirect_if_not_owner, only: [:edit, :update]
+  # ログイン状態でのみアクセス可能なアクションを指定
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
 
+  # 対象の商品を取得するbefore_actionを追加
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+
+  # 出品者以外はアクセスできないようにリダイレクトするbefore_action
+  before_action :redirect_if_not_owner, only: [:edit, :update, :destroy]
+
+  # 商品一覧ページ
   def index
     @items = Item.includes(:user).order(created_at: :desc) # 商品を取得して変数に格納
   end
 
+  # 商品出品ページ
   def new
     @item = Item.new
   end
 
+  # 商品出品処理
   def create
     @item = Item.new(item_params)
     if @item.save
-      redirect_to root_path
+      redirect_to root_path # 出品成功後、トップページにリダイレクト
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_entity # 出品失敗時、エラー表示
     end
   end
 
-  def show  
+  # 商品詳細ページ
+  def show
+    # set_item で @item を取得済み
   end
 
-  def edit 
+  # 商品編集ページ
+  def edit
+    # set_item で @item を取得済み
   end
 
+  # 商品更新処理
   def update
+    # set_item で @item を取得済み
     if @item.update(item_params)
-      redirect_to item_path(@item)
+      redirect_to item_path(@item) # 更新成功後、商品詳細ページにリダイレクト
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_entity # 更新失敗時、エラー表示
     end
+  end
+
+  # 商品削除処理
+  def destroy
+    @item.destroy # 商品削除
+    redirect_to root_path # 削除後、トップページにリダイレクト
   end
 
   private
 
+  # Strong Parameters - 商品情報を許可する
   def item_params
     params.require(:item).permit(:name, :description, :category_id, :condition_id, :shipping_fee_id, :prefecture_id,
-                                 :shipping_day_id, :price, :image).merge(user_id: current_user.id)
+                                 :shipping_day_id, :price, :image).merge(user_id: current_user.id) # 出品者IDを加える
   end
 
-  # 対象の@itemを取得
+  # 対象の商品を取得
   def set_item
-    @item = Item.find(params[:id])
+    @item = Item.find(params[:id]) # URLのIDから商品を取得
   end
 
   # 出品者以外をトップページにリダイレクト
   def redirect_if_not_owner
-    return if current_user == @item.user
+    return if current_user == @item.user # 出品者が一致していれば処理を進める
 
-    redirect_to root_path
+    redirect_to root_path # 出品者でなければトップページにリダイレクト
   end
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
       <% if current_user == @item.user %>
         <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
       <% else %>
         <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users # Deviseによるユーザー認証ルート
 
   # アイテム関連のルート
-  resources :items, only: [:new, :create, :index, :show, :edit, :update]
+  resources :items, only: [:new, :create, :index, :show, :edit, :update, :destroy]
 
   # ルートページの設定
   root to: "items#index"


### PR DESCRIPTION
## What（何を実装したか）

- ログイン状態で、自身が出品した商品情報のみ削除できるように実装しました。
- 商品が削除された後、トップページに遷移するようにしました。
- 商品詳細ページに、出品者が自身の商品を削除するためのリンクを追加しました。削除の際は確認ダイアログを表示し、削除後にトップページにリダイレクトされる仕様です。


## Why（なぜ実装したか）

- 商品削除機能は、出品者が自身の商品を管理できる基本的な操作の1つであり、他のユーザーが他人の商品を削除できないように制限する必要があるため、この実装を行いました。
- 削除後にトップページに遷移することで、ユーザーが他の商品を確認することができ、UXを向上させるためです。




ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://i.gyazo.com/a4d20f84cdd1daf4f8e36c76174d7309.mp4



